### PR TITLE
Adding Cartfile and updated dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,3 @@
+github "jpsim/Yams" "nn-dylib-versions"
+github "krzysztofzablocki/KZFileWatchers" ~> 1.0.5
+


### PR DESCRIPTION
Added a Carthfile so carthage would build the dependant frameworks. Also updated Yams to a test version which has a correct framework version number.

I found that if I checked out Stylist and built it in Xcode it would build the dependencies in the Pods directories. But if I built it using Carthage it would not place the framework files in Carthage's Build directory. I think this is a quirk of basing a project on CocoaPods templates. Anyway, the Carthage file is all that's needed to correctly build Stylist and it's dependencies and make them available.